### PR TITLE
Fix on URLs that has invalid hostnames

### DIFF
--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -20,7 +20,7 @@ module ActiveModel
         schemes = [*options.fetch(:schemes)].map(&:to_s)
         begin
           uri = Addressable::URI.parse(value)
-          unless uri && uri.host && schemes.include?(uri.scheme) && (!options.fetch(:no_local) || uri.host.include?('.'))
+          unless uri && value.include?(uri.origin + uri.path) && schemes.include?(uri.scheme) && (!options.fetch(:no_local) || uri.host.include?('.'))
             record.errors.add(attribute, options.fetch(:message), :value => value)
           end
         rescue Addressable::URI::InvalidURIError

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -56,7 +56,7 @@ describe "URL validation" do
       @user.homepage = "http://"
       @user.should_not be_valid
     end
-    
+
     it "should not allow a url without a host" do
       @user.homepage = "http:/"
       @user.should_not be_valid
@@ -65,6 +65,11 @@ describe "URL validation" do
     it "should allow a url with an underscore" do
       @user.homepage = "http://foo_bar.com"
       @user.should be_valid
+    end
+
+    it "should not allow a url with a repeated scheme" do
+      @user.homepage = "http://http://foo_bar.com"
+      @user.should_not be_valid
     end
 
     it "should return a default error message" do


### PR DESCRIPTION
I wrote an extra fix for validations that doesn't allow local URLs to have weird hostnames as well (e.g. tel://tel://10923213).
